### PR TITLE
Change Azure Pipeline VM image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://aka.ms/yaml
 
 pool:
-  vmImage: 'win1803'
+  vmImage: 'windows-latest'
 
 steps:
   - script: |


### PR DESCRIPTION
The win1803 image is being deprecated. This changes to a supported one.